### PR TITLE
Updated authentication labels

### DIFF
--- a/certified-connectors/iAuditor/apiProperties.json
+++ b/certified-connectors/iAuditor/apiProperties.json
@@ -6,7 +6,7 @@
         "uiDefinition": {
           "displayName": "API token",
           "description": "Input format: 'Bearer <token>",
-          "tooltip": "Provide your API token in the format: 'Bearer <token>'. e.g., 'Bearer your_api_token'"
+          "tooltip": "Provide your API token in the format: 'Bearer <token>'. e.g., 'Bearer your_api_token'",
           "constraints": {
             "tabIndex": 2,
             "clearText": false,

--- a/certified-connectors/iAuditor/apiProperties.json
+++ b/certified-connectors/iAuditor/apiProperties.json
@@ -4,9 +4,9 @@
       "api_key": {
         "type": "securestring",
         "uiDefinition": {
-          "displayName": "API Key",
-          "description": "The API Key for this api",
-          "tooltip": "Provide your API Key",
+          "displayName": "API token",
+          "description": "Input format: 'Bearer <token>",
+          "tooltip": "Provide your API token in the format: 'Bearer <token>'. e.g., 'Bearer your_api_token'"
           "constraints": {
             "tabIndex": 2,
             "clearText": false,


### PR DESCRIPTION
Updated to the authentication label, description, and tooltip. This is to instruct users more clearly on how to input the API token in the accepted format of 'Bearer <token>'.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
